### PR TITLE
Changed service name to influxdb since localhost is a reserved hostname

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     depends_on:
       - zookeeper
 
-  localhost:
+  influxdb:
       image: influxdb:latest
       container_name: influxdb
       ports:


### PR DESCRIPTION
Using `localhost` as a service name in docker compose is dangerous since services within a composition get a hostname named for their service name. So, if the grafana container addressed "localhost" it would be ambiguous whether that's 127.0.0.1 or the influxdb container.