### PR TITLE
Bumped InfluxDB to 1.8 since it improves placeholder support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - zookeeper
 
   influxdb:
-      image: influxdb:${INFLUXDB_VERSION:-1.7-alpine}
+      image: influxdb:${INFLUXDB_VERSION:-1.8-alpine}
       container_name: influxdb
       ports:
           - "8086:8086"


### PR DESCRIPTION
# What

Running against 1.7, the query services reports the error:

```
"message": "error parsing query: found $measurement, expected identifier at line 1, char 20",
    "rootCause": "error parsing query: found $measurement, expected identifier at line 1, char 20"
```

With 1.8 there's still a bug in the app code, but at least the binding works:
```
"message": "error parsing query: found devMeasurement1, expected identifier at line 1, char 20",
    "rootCause": "error parsing query: found devMeasurement1, expected identifier at line 1, char 20"
```

Thanks @Yurochkina , for gathering those findings.

# How

Bump InfluxDB to 1.8. (Helm charts will also need to be bumped at some point.)